### PR TITLE
Remove one empty section added by accident

### DIFF
--- a/spec/src/main/asciidoc/microprofile-graphql-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-graphql-spec.asciidoc
@@ -36,7 +36,6 @@ endif::[]
 
 include::license-efsl.adoc[]
 
-== MicroProfile GraphQL
 include::intro.asciidoc[]
 
 include::entities.asciidoc[]


### PR DESCRIPTION
As part of ballot review process, it was noted that one extra section in the spec did not make sense. It seems this line was added by accident, which was there from the v1.0.